### PR TITLE
ukrainian: change ё to apostrophe

### DIFF
--- a/packages/InputDevices/res/raw/keyboard_layout_ukrainian.kcm
+++ b/packages/InputDevices/res/raw/keyboard_layout_ukrainian.kcm
@@ -35,87 +35,85 @@ key GRAVE {
 key 1 {
     label:                              '1'
     base:                               '1'
-    shift, capslock:                    '!'
+    shift:                              '!'
     ralt:                               '!'
 }
 
 key 2 {
     label:                              '2'
     base:                               '2'
-    shift, capslock:                    '@'
+    shift:                              '@'
     ralt:                               '@'
 }
 
 key 3 {
     label:                              '3'
     base:                               '3'
-    shift, capslock:                    '\u2116'
+    shift:                              '\u2116'
     ralt:                               '#'
 }
 
 key 4 {
     label:                              '4'
     base:                               '4'
-    shift, capslock:                    ';'
+    shift:                              ';'
     ralt:                               '$'
 }
 
 key 5 {
     label:                              '5'
     base:                               '5'
-    shift, capslock:                    '%'
+    shift:                              '%'
     ralt:                               '%'
 }
 
 key 6 {
     label:                              '6'
     base:                               '6'
-    shift, capslock:                    ':'
+    shift:                              ':'
     ralt:                               '^'
 }
 
 key 7 {
     label:                              '7'
     base:                               '7'
-    shift, capslock:                    '?'
+    shift:                              '?'
     ralt:                               '&'
 }
 
 key 8 {
     label:                              '8'
     base:                               '8'
-    shift, capslock:                    '*'
+    shift:                              '*'
     ralt:                               '*'
 }
 
 key 9 {
     label:                              '9'
     base:                               '9'
-    shift, capslock:                    '('
+    shift:                              '('
     ralt:                               '('
 }
 
 key 0 {
     label:                              '0'
     base:                               '0'
-    shift, capslock:                    ')'
+    shift:                              ')'
     ralt:                               ')'
 }
 
 key MINUS {
     label:                              '-'
     base:                               '-'
-    shift, capslock:                    '_'
-    ralt:                               '-'
-    ralt+shift:                         '_'
+    shift:                              '_'
+    ralt:                               '_'
 }
 
 key EQUALS {
     label:                              '='
     base:                               '='
-    shift, capslock:                    '+'
-    ralt:                               '='
-    ralt+shift:                         '+'
+    shift:                              '+'
+    ralt:                               '+'
 }
 
 ### ROW 2

--- a/packages/InputDevices/res/raw/keyboard_layout_ukrainian.kcm
+++ b/packages/InputDevices/res/raw/keyboard_layout_ukrainian.kcm
@@ -25,9 +25,9 @@ map key 86 PLUS
 ### ROW 1
 
 key GRAVE {
-    label:                              '\u0401'
-    base:                               '\u0451'
-    shift, capslock:                    '\u0401'
+    label:                              '\''
+    base:                               '\''
+    shift:                              '"'
     ralt:                               '`'
     ralt+shift:                         '~'
 }
@@ -42,7 +42,7 @@ key 1 {
 key 2 {
     label:                              '2'
     base:                               '2'
-    shift, capslock:                    '"'
+    shift, capslock:                    '@'
     ralt:                               '@'
 }
 

--- a/packages/InputDevices/res/raw/keyboard_layout_ukrainian.kcm
+++ b/packages/InputDevices/res/raw/keyboard_layout_ukrainian.kcm
@@ -305,20 +305,20 @@ key APOSTROPHE {
 }
 
 key BACKSLASH {
-    label:                              '\\'
-    base:                               '\\'
-    shift, capslock:                    '/'
-    ralt:                               '|'
+    label:                              '\u0490'
+    base:                               '\u0491'
+    shift, capslock:                    '\u0490'
+    ralt:                               '\\'
+    ralt+shift, ralt+capslock:          '/'
 }
 
 ### ROW 4
 
 key PLUS {
-    label:                              '\u0490'
-    base:                               '\u0491'
-    shift, capslock:                    '\u0490'
-    ralt:                               '\\'
-    ralt+shift:                         '|'
+    label:                              '\\'
+    base:                               '\\'
+    shift, capslock:                    '/'
+    ralt:                               '|'
 }
 
 key Z {


### PR DESCRIPTION
Ukrainian has no letter "ё" but it has apostrophe. So now users don't have to change layout to English
